### PR TITLE
Don't break headless services when backing them up

### DIFF
--- a/lib/kube_backup.rb
+++ b/lib/kube_backup.rb
@@ -241,7 +241,9 @@ module KubeBackup
     end
 
     if resource["kind"] == "Service" && resource["spec"]
-      resource["spec"].delete("clusterIP")
+      if resource["spec"]["clusterIP"] != "None"
+        resource["spec"].delete("clusterIP")
+      end
       if resource["spec"] == {}
         resource.delete("spec")
       end


### PR DESCRIPTION
Setting the cluster IP to the magical value of 'None' changes how DNS treats them, which lets you use them for endpoint discovery using simple DNS queries - Kubernetes own [peer-finder](https://github.com/kubernetes/contrib/tree/master/peer-finder) for instance uses this.