### PR TITLE
Remove first double quotes of namespace in commit message

### DIFF
--- a/lib/kube_backup.rb
+++ b/lib/kube_backup.rb
@@ -318,6 +318,7 @@ module KubeBackup
         info["file"].sub!(prefix, '') if prefix
         file_parts = info["file"].sub(/\.yaml$/, '').split("/")
         if file_parts[0] != "_global_"
+          file_parts[0].sub!(/^"/, '')
           namespaces << file_parts[0]
         end
         resources << file_parts[1]


### PR DESCRIPTION
fixes #6 
Error occured if k8s objects have whitespaces in their name, because the commit message has a double quote.
e.g.  `RUN git commit -m "ConfigMap, Deployment in namespaces "hello"`
-> `error: sh: syntax error: unterminated quoted string`